### PR TITLE
Fix an issue with boolean config

### DIFF
--- a/lib/configit/base.rb
+++ b/lib/configit/base.rb
@@ -148,7 +148,7 @@ module Configit
 
         @attribute_module.class_eval do
           define_method name do
-            value = attributes[name] || attr.default
+            value = attributes[name].nil? ? attr.default : attributes[name]
             if value != nil
               @@converters[attr.type].call(value)
             else


### PR DESCRIPTION
Fix an issue where `false` in boolean config is ignored by `||` when default is `true`.

To be specific:
```
# before
attributes[name] = false, attr.default = true 
=> value = true

# after
attributes[name] = false, attr.default = true 
=> value = false
```

I've unit tested this in sandbox by pointing the gem `configit` to my fork.